### PR TITLE
fix embed notebook example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can also embed marimo files directly:
     filepath: path/to/your/file.py
     height: 400px
     mode: read
-    show_source: true
+    show_source: 'true'
 ///
 ````
 


### PR DESCRIPTION
This fails without single quotes for me locally, I did not test the other options.