### PR TITLE
fix: issue in example causing the block to not render

### DIFF
--- a/docs/getting-started/blocks.md
+++ b/docs/getting-started/blocks.md
@@ -189,13 +189,14 @@ def __():
 ### marimo-embed-file
 
 The `marimo-embed-file` block is used to embed existing marimo files:
-
+```
 /// marimo-embed-file
     filepath: getting-started/inlined.py
     height: 600px
     mode: read
-    show_source: true
+    show_source: "true"
 ///
+```
 
 | Option | Description | Default |
 | --- | --- | --- |


### PR DESCRIPTION
This really tripped me up for a while, so I hope this can help someone else. 

If the `true` is not quoted in `show_source: "true"`, the whole block just refuses to render, and is interpreted as text. 

