### PR TITLE
ci: adopt deny-all top-level workflow permissions

### DIFF
--- a/.github/workflows/bump-lockfile.yml
+++ b/.github/workflows/bump-lockfile.yml
@@ -1,8 +1,6 @@
 name: Update lockfiles
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 on:
   workflow_dispatch:
@@ -35,3 +33,6 @@ jobs:
           labels: pixi
           delete-branch: true
           add-paths: pixi.lock
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
Sets each workflow's top-level `permissions:` to `{}` (deny-all) and moves the previously top-level grants into the specific jobs that inherited them. **Effective permissions are unchanged for every job** — this just makes the grants explicit per job so a newly-added job can't silently inherit broad scopes.

Behavior-preserving mechanical change (validated: all touched workflows still parse; per-job effective scopes identical). Workflows whose jobs inherit the org default are left untouched for a manual per-job pass.

_Flagged by github-maintenance Workflow Permissions Audit._