### PR TITLE
docs: add AGENTS.md with CLAUDE.md symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# mkdocs-marimo
+
+MkDocs plugin that renders reactive marimo cells in Markdown docs. Published to PyPI as `mkdocs-marimo`.
+
+## Development
+
+Tooling is driven by [pixi](https://pixi.sh) (all tasks defined in `pixi.toml`):
+
+```bash
+pixi run postinstall           # editable install into the env
+pixi run test                  # pytest
+pixi run mypy mkdocs_marimo    # type check
+pixi run pre-commit-run        # lint/format (ruff, taplo, typos) — matches CI lint job
+pixi run docs                  # serve docs locally (pixi run docs-build to build)
+```
+
+- CI runs `test` + `mypy` across the `py39`–`py313` environments (`pixi run -e py312 test`).
+- No pixi? These map to `pytest`, `mypy`, and `pre-commit run -a` under the env deps in `pixi.toml`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Adopts the marimo-team convention where AGENTS.md is the canonical agent-context doc and CLAUDE.md is a symlink to it (`ln -s AGENTS.md CLAUDE.md`), so every agent reads one source of truth. The doc is deliberately minimal — a one-line overview plus verified development commands — because it loads into every agent context and fewer tokens is better. Part of the marimo-team engineering-excellence initiative to give agents consistent, low-overhead repo context.